### PR TITLE
refactor(back): dynamic routing for all-videos

### DIFF
--- a/pages/api/all-videos/[language].js
+++ b/pages/api/all-videos/[language].js
@@ -1,6 +1,24 @@
 import { YouTube } from 'popyt';
 
-export default (key, channelId) => async (req, res) => {
+const getChannelData = key => {
+	const mapper = {
+		en: process.env.YOUTUBE_CHANNEL_EN,
+		es: process.env.YOUTUBE_CHANNEL_ES,
+	};
+
+	return {
+		key: process.env.YOUTUBE_KEY,
+		channelId: mapper[key],
+	};
+};
+
+export default async (req, res) => {
+	const {
+		query: { language },
+	} = req;
+
+	const { key, channelId } = getChannelData(language);
+
 	const youtube = new YouTube(key);
 
 	const playlists = await youtube.getChannelPlaylists(channelId);
@@ -30,8 +48,6 @@ export default (key, channelId) => async (req, res) => {
 			};
 		}),
 	);
-
-	console.log({ items });
 
 	res.status(200).json({ items });
 };

--- a/pages/api/en/all-videos.js
+++ b/pages/api/en/all-videos.js
@@ -1,9 +1,0 @@
-import getAllVideosByPlaylist from '../_utils/all-videos';
-
-export default async function get(req, res) {
-
-	const key = process.env.YOUTUBE_KEY;
-	const channelId = process.env.YOUTUBE_CHANNEL_EN;
-
-	return await getAllVideosByPlaylist(key, channelId)(req, res);
-}

--- a/pages/api/es/all-videos.js
+++ b/pages/api/es/all-videos.js
@@ -1,8 +1,0 @@
-import getAllVideosByPlaylist from '../_utils/all-videos';
-
-export default async function get(req, res) {
-	const key = process.env.YOUTUBE_KEY;
-	const channelId = process.env.YOUTUBE_CHANNEL_ES;
-
-	return await getAllVideosByPlaylist(key, channelId)(req, res);
-}

--- a/pages/es/index.js
+++ b/pages/es/index.js
@@ -11,7 +11,7 @@ export async function getStaticProps({ req }) {
 			? 'http://localhost:3001'
 			: process.env.PROD_URL;
 
-	const res = await fetch(`${baseUrl}/api/all-videos/es`);
+  const res = await fetch(`${baseUrl}/api/es/all-videos/`);
 
 	const playlists = await res.json();
 

--- a/pages/es/index.js
+++ b/pages/es/index.js
@@ -6,14 +6,12 @@ export default function Index({ playlists }) {
 }
 
 export async function getStaticProps({ req }) {
-	// Call an external API endpoint to get posts.
-  console.log({req});
 	const baseUrl =
 		process.env.APP_ENVIRONMENT === 'development'
 			? 'http://localhost:3001'
-			: 'https://frontend-topics-v2.now.sh';
+			: process.env.PROD_URL;
 
-	const res = await fetch(`${baseUrl}/api/es/all-videos`);
+	const res = await fetch(`${baseUrl}/api/all-videos/es`);
 
 	const playlists = await res.json();
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,7 @@ export async function getStaticProps({ req }) {
 			? 'http://localhost:3001'
 			: process.env.PROD_URL;
 
-	const res = await fetch(`${baseUrl}/api/all-videos/en`);
+  const res = await fetch(`${baseUrl}/api/en/all-videos/`);
 
 	const playlists = await res.json();
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,14 +6,12 @@ export default function Index({ playlists }) {
 }
 
 export async function getStaticProps({ req }) {
-	// Call an external API endpoint to get posts.
-  console.log(process);
 	const baseUrl =
 		process.env.APP_ENVIRONMENT === 'development'
 			? 'http://localhost:3001'
 			: process.env.PROD_URL;
 
-	const res = await fetch(`${baseUrl}/api/en/all-videos`);
+	const res = await fetch(`${baseUrl}/api/all-videos/en`);
 
 	const playlists = await res.json();
 

--- a/pages/views/home/index.js
+++ b/pages/views/home/index.js
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-import fetch from 'node-fetch';
 import Card from '../../components/card';
 import Layout from '../../components/layout';
 


### PR DESCRIPTION
Ok, so still I wasn't able to load different indexes using a language. 

My idea was to have something like: 
```
/pages
 L[languages].js
```

But it's not possible to do it, because we need a index at the root. Wrapping everything in a folder
would work BUT, I would have to route from index to the home folder. 
```
/pages
 L/home
 LL[languages].js
```

At least I was able to introduce dynamic routing for all-videos. This change introduce to new endpoints

all-videos/en
all-videos/es